### PR TITLE
Handle edge case: expect(null).not.toBeInTheDocument()

### DIFF
--- a/tests/jest-dom-matchers/toBeInTheDocument.test.ts
+++ b/tests/jest-dom-matchers/toBeInTheDocument.test.ts
@@ -24,5 +24,17 @@ test(
 
             [31melement could not be found in the document[39m"
           `);
+    const notInDoc = await screen.queryByText('not in the document');
+    expect(notInDoc).toBeNull();
+    // special case: expect(null).not.toBeInTheDocument() should pass
+    // even though notInDoc is null and not an ElementHandle
+    expect(notInDoc).not.toBeInTheDocument();
+    await expect(expect(notInDoc).toBeInTheDocument()).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "[2mexpect([22m[31mreceived[39m[2m).toBeInTheDocument()[22m
+
+            [31mreceived[39m value must be an HTMLElement or an SVGElement.
+            Received has value: [31mnull[39m"
+          `);
   }),
 );


### PR DESCRIPTION
This edge case may be fairly common because it is recommended in the [testing-library docs](https://testing-library.com/docs/guide-disappearance#nottobeinthedocument):

> The jest-dom utility library provides the .toBeInTheDocument() matcher, which can be used to assert that an element is in the body of the document, or not. This can be more meaningful than asserting a query result is null.
> 
> ```js
> import '@testing-library/jest-dom/extend-expect'
> // use `queryBy` to avoid throwing an error with `getBy`
> const submitButton = screen.queryByText('submit')
> expect(submitButton).not.toBeInTheDocument()
> ```

This is good because in the failure case, where the unexpected element _is_ found, you get an error message like this:

> expected document not to contain element, found \<div /> instead