### PR TITLE
Change from debug() to `return false`, and fix browser cleanup bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,8 @@ export const withBrowser: WithBrowser = (testFn, { headless = true } = {}) => {
         ctx.page.browser().disconnect();
         throw error;
       });
-    if (!leaveBrowserOpen) {
-      // close since test passed
-      await ctx.page.close();
-    }
+    // close since test passed
+    if (!leaveBrowserOpen) await ctx.page.close();
     ctx.page.browser().disconnect();
   };
 };

--- a/tests/utils/runJS.test.ts
+++ b/tests/utils/runJS.test.ts
@@ -146,10 +146,6 @@ test(
       )
       .catch((error) => error);
 
-    expect(error).toMatchInlineSnapshot(
-      `[Error: you have rendered the death component]`,
-    );
-
     expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
       "Error: you have rendered the death component
       -------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/cloudfour/test-mule/issues/15
Fixes https://github.com/cloudfour/test-mule/issues/19

For #19:

Reproduction (error about unclosed instances should show up on `main`, most of the time, and never on this branch)

```js
import { withBrowser } from 'test-mule';

test(
  'passing',
  withBrowser(async ({ page }) => {
    await page.goto('https://google.com')
  }),
);

test(
  'failing',
  withBrowser(async ({ page }) => {
    expect(4).toEqual(43424);
  }),
);
```

For #15:

```js
import { withBrowser } from 'test-mule';

test(
  'passing',
  withBrowser(async ({ page }) => {
    await page.goto('https://google.com')
    return false
  }),
);
```

`return false` tells `test-mule` to leave the browser open, even if the test passes (but only for headed browsers; headless browsers are always closed)

Diff without whitespace: https://github.com/cloudfour/test-mule/pull/23/files?diff=split&w=1