### PR TITLE
Handle forgotten await

### DIFF
--- a/.changeset/heavy-emus-walk.md
+++ b/.changeset/heavy-emus-walk.md
@@ -2,7 +2,7 @@
 'test-mule': minor
 ---
 
-Provide a helpful message if the user forgets to use `await`,
+Provide a helpful message if the user forgets to use `await`.
 
 For example, if a user forgets to use `await` in the jest-dom assertion:
 

--- a/.changeset/heavy-emus-walk.md
+++ b/.changeset/heavy-emus-walk.md
@@ -1,0 +1,34 @@
+---
+'test-mule': minor
+---
+
+Provide a helpful message if the user forgets to use `await`,
+
+For example, if a user forgets to use `await` in the jest-dom assertion:
+
+```js
+test(
+  'example',
+  withBrowser(async ({ screen, utils }) => {
+    await utils.injectHTML('<button>Hi</button>');
+    const button = await screen.getByText(/hi/i);
+    expect(button).toBeVisible();
+  }),
+);
+```
+
+Then a useful error message is produced:
+
+```
+Cannot execute assertion toBeVisible after test finishes. Did you forget to await?
+
+  103 |     await utils.injectHTML('<button>Hi</button>');
+  104 |     const button = await screen.getByText(/hi/i);
+> 105 |     expect(button).toBeVisible();
+      |                    ^
+  106 |   }),
+  107 | );
+  108 |
+```
+
+This is also handled for utility functions, user methods, and Testing Library queries.

--- a/src/user.ts
+++ b/src/user.ts
@@ -10,43 +10,59 @@ export interface TestMuleUser {
   click(element: ElementHandle | null): Promise<void>;
 }
 
-export const testMuleUser = () => {
+export const testMuleUser = (state: { isTestFinished: boolean }) => {
   const user: TestMuleUser = {
     async click(el) {
       assertElementHandle(el, user.click, 'user.click(el)', 'el');
 
-      const failed = await el.evaluateHandle((clickEl) => {
-        const clickElRect = clickEl.getBoundingClientRect();
+      const forgotAwaitError = removeFuncFromStackTrace(
+        new Error(
+          `Cannot interact with browser using user.click after test finishes. Did you forget to await?`,
+        ),
+        user.click,
+      );
 
-        // See if there is an element covering the center of the click target element
-        const coveringEl = document.elementFromPoint(
-          Math.floor(clickElRect.x + clickElRect.width / 2),
-          Math.floor(clickElRect.y + clickElRect.height / 2),
-        );
-        if (coveringEl === clickEl || clickEl.contains(coveringEl)) return;
-        // TODO: try to find other points on the element that are clickable,
-        // in case the covering element does not cover the whole click-target element
-        const messagePart1 =
-          'user.click(element)\n\nCould not click element:\n';
-        const messagePart2 = '\n\nElement was covered by:\n';
-        // TODO: instead of using .outerHTML use the html formatter
-        return {
-          message:
-            messagePart1 +
-            clickEl.outerHTML +
-            messagePart2 +
-            coveringEl!.outerHTML,
-          messageForBrowser: [messagePart1, clickEl, messagePart2, coveringEl],
-        };
-      });
+      const failed = await el
+        .evaluateHandle((clickEl) => {
+          const clickElRect = clickEl.getBoundingClientRect();
 
-      if (await failed.jsonValue()) {
-        const error = new Error(
-          (await failed
-            .getProperty('message')
-            .then((r) => r.jsonValue())) as any,
-        );
-        // @ts-expect-error
+          // See if there is an element covering the center of the click target element
+          const coveringEl = document.elementFromPoint(
+            Math.floor(clickElRect.x + clickElRect.width / 2),
+            Math.floor(clickElRect.y + clickElRect.height / 2),
+          );
+          if (coveringEl === clickEl || clickEl.contains(coveringEl)) return;
+          // TODO: try to find other points on the element that are clickable,
+          // in case the covering element does not cover the whole click-target element
+          const messagePart1 =
+            'user.click(element)\n\nCould not click element:\n';
+          const messagePart2 = '\n\nElement was covered by:\n';
+          // TODO: instead of using .outerHTML use the html formatter
+          return {
+            message:
+              messagePart1 +
+              clickEl.outerHTML +
+              messagePart2 +
+              coveringEl!.outerHTML,
+            messageForBrowser: [
+              messagePart1,
+              clickEl,
+              messagePart2,
+              coveringEl,
+            ],
+          };
+        })
+        .catch((error) => {
+          if (state.isTestFinished && /target closed/i.test(error.message)) {
+            throw forgotAwaitError;
+          }
+          throw error;
+        });
+
+      const { message } = (await failed.jsonValue()) || ({} as any);
+
+      if (message) {
+        const error = new Error(message) as any;
         error.messageForBrowser = await jsHandleToArray(
           await failed.getProperty('messageForBrowser'),
         );

--- a/tests/forgot-await.test.ts
+++ b/tests/forgot-await.test.ts
@@ -1,0 +1,98 @@
+import { withBrowser } from 'test-mule';
+import { printErrorFrames } from './test-utils';
+
+test('forgot await in testing library query', (done) => {
+  withBrowser(async ({ screen }) => {
+    screen.getByText('hi').catch(async (error) => {
+      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+        "Error: Cannot execute query getByText after test finishes. Did you forget to await?
+        -------------------------------------------------------
+        tests/forgot-await.test.ts
+
+            screen.getByText('hi').catch(async (error) => {
+                   ^
+        -------------------------------------------------------
+        dist/cjs/index.cjs"
+      `);
+      done();
+    });
+  })();
+});
+
+test('forgot await in jest dom assertion', (done) => {
+  withBrowser(async ({ screen, utils }) => {
+    await utils.injectHTML('<button>Hi</button>');
+    const button = await screen.getByText(/hi/i);
+    expect(button)
+      .toBeVisible()
+      .catch(async (error) => {
+        expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+          "Error: Cannot execute assertion toBeVisible after test finishes. Did you forget to await?
+          -------------------------------------------------------
+          tests/forgot-await.test.ts
+
+                .toBeVisible()
+                 ^
+          -------------------------------------------------------
+          dist/cjs/index.cjs"
+        `);
+        done();
+      });
+  })();
+});
+
+test('forgot await in utils.injectHTML', (done) => {
+  withBrowser(async ({ utils }) => {
+    utils.injectHTML('<button>Hi</button>').catch(async (error) => {
+      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+        "Error: Cannot interact with browser using injectHTML after test finishes. Did you forget to await?
+        -------------------------------------------------------
+        tests/forgot-await.test.ts
+
+            utils.injectHTML('<button>Hi</button>').catch(async (error) => {
+                  ^
+        -------------------------------------------------------
+        dist/cjs/index.cjs"
+      `);
+      done();
+    });
+  })();
+});
+
+test('forgot await in utils.runJS', (done) => {
+  withBrowser(async ({ utils }) => {
+    utils.runJS('if (false) {}').catch(async (error) => {
+      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+        "Error: Cannot interact with browser using runJS after test finishes. Did you forget to await?
+        -------------------------------------------------------
+        tests/forgot-await.test.ts
+
+            utils.runJS('if (false) {}').catch(async (error) => {
+                  ^
+        -------------------------------------------------------
+        dist/cjs/index.cjs"
+      `);
+      done();
+    });
+  })();
+});
+
+test('forgot await in user.click', (done) => {
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML('<button>Hi</button>');
+    const button = await screen.getByText('Hi');
+    user.click(button).catch(async (error) => {
+      expect(await printErrorFrames(error)).toMatchInlineSnapshot(`
+        "Error: Cannot interact with browser using user.click after test finishes. Did you forget to await?
+        -------------------------------------------------------
+        tests/forgot-await.test.ts
+
+            user.click(button).catch(async (error) => {
+                 ^
+        -------------------------------------------------------
+        dist/cjs/index.cjs"
+      `);
+      done();
+    });
+  })();
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -22,10 +22,12 @@ export const printErrorFrames = async (error: Error) => {
         ) {
           return stackFrame.raw;
         }
+        const relativePath = path.relative(process.cwd(), stackFrame.fileName);
+        if (relativePath.startsWith('dist/')) return relativePath;
         const file = await fs.readFile(stackFrame.fileName, 'utf8');
         const line = file.split('\n')[stackFrame.line - 1];
         return (
-          path.relative(process.cwd(), stackFrame.fileName) +
+          relativePath +
           '\n\n' +
           line +
           '\n' +


### PR DESCRIPTION
Provide a helpful message if the user forgets to use `await`,

For example, if a user forgets to use `await` in the jest-dom assertion:

```js
test(
  'example',
  withBrowser(async ({ screen, utils }) => {
    await utils.injectHTML('<button>Hi</button>');
    const button = await screen.getByText(/hi/i);
    expect(button).toBeVisible();
  }),
);
```

Then a useful error message is produced:

```
Cannot execute assertion toBeVisible after test finishes. Did you forget to await?

  103 |     await utils.injectHTML('<button>Hi</button>');
  104 |     const button = await screen.getByText(/hi/i);
> 105 |     expect(button).toBeVisible();
      |                    ^
  106 |   }),
  107 | );
  108 |
```

This is also handled for utility functions, user methods, and Testing Library queries.

Closes #30 