### PR TITLE
Add ability to pass arguments to browser in runJS

### DIFF
--- a/.changeset/proud-numbers-grin.md
+++ b/.changeset/proud-numbers-grin.md
@@ -1,0 +1,24 @@
+---
+'test-mule': minor
+---
+
+Add ability to pass variables to the browser in runJS:
+
+```js
+import { withBrowser } from 'test-mule';
+
+test(
+  'runJS example with argument',
+  withBrowser(async ({ utils, screen }) => {
+    // element is an ElementHandle (pointer to an element in the browser)
+    const element = await screen.getByText(/button/i);
+    // we can pass element into runJS and the default exported function can access it as an Element
+    await utils.runJS(
+      `
+        export default (element) => console.log(element);
+      `,
+      [element],
+    );
+  }),
+);
+```

--- a/.changeset/proud-numbers-grin.md
+++ b/.changeset/proud-numbers-grin.md
@@ -2,7 +2,7 @@
 'test-mule': minor
 ---
 
-Add ability to pass variables to the browser in runJS:
+Now it is possible to pass variables to the browser in runJS:
 
 ```js
 import { withBrowser } from 'test-mule';

--- a/README.md
+++ b/README.md
@@ -441,6 +441,27 @@ test(
 );
 ```
 
+To pass variables from the test environment into the browser, you can pass them as the 2nd parameter. Note that they must either be JSON-serializable or they can be a [`JSHandle`](https://pptr.dev/#?product=Puppeteer&version=v7.1.0&show=api-class-jshandle) or an [`ElementHandle`](https://pptr.dev/#?product=Puppeteer&version=v7.1.0&show=api-class-elementhandle). The arguments can be received in the browser as parameters to a default-exported function:
+
+```js
+import { withBrowser } from 'test-mule';
+
+test(
+  'runJS example with argument',
+  withBrowser(async ({ utils, screen }) => {
+    // element is an ElementHandle (pointer to an element in the browser)
+    const element = await screen.getByText(/button/i);
+    // we can pass element into runJS and the default exported function can access it as an Element
+    await utils.runJS(
+      `
+        export default (element) => console.log(element);
+      `,
+      [element],
+    );
+  }),
+);
+```
+
 #### `TestMuleUtils.loadJS(jsPath: string): Promise<void>`
 
 Load a JS (or TS, JSX) file into the browser. Pass a path that will be resolved from your test file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "test-mule",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/utils/runJS.test.ts
+++ b/tests/utils/runJS.test.ts
@@ -39,24 +39,16 @@ test(
 
     await utils.runJS(
       `
-        export default (heading) => {
+        export default (heading, object) => {
           if (heading.outerHTML !== "<h1>I'm a heading</h1>") {
             throw new Error('element was not passed correctly')
           }
-        }
-      `,
-      [heading],
-    );
-
-    await utils.runJS(
-      `
-        export default (object) => {
           if (object.some.serializable.value !== false) {
             throw new Error('object was not passed correctly')
           }
         }
       `,
-      [{ some: { serializable: { value: false } } }],
+      [heading, { some: { serializable: { value: false } } }],
     );
   }),
 );

--- a/tests/utils/runJS.test.ts
+++ b/tests/utils/runJS.test.ts
@@ -32,6 +32,35 @@ test(
   }),
 );
 
+test(
+  'allows passing ElementHandles and serializable values into browser',
+  withBrowser(async ({ utils, screen }) => {
+    const heading = await createHeading({ utils, screen });
+
+    await utils.runJS(
+      `
+        export default (heading) => {
+          if (heading.outerHTML !== "<h1>I'm a heading</h1>") {
+            throw new Error('element was not passed correctly')
+          }
+        }
+      `,
+      [heading],
+    );
+
+    await utils.runJS(
+      `
+        export default (object) => {
+          if (object.some.serializable.value !== false) {
+            throw new Error('object was not passed correctly')
+          }
+        }
+      `,
+      [{ some: { serializable: { value: false } } }],
+    );
+  }),
+);
+
 describe('Waiting for Promises in executed code', () => {
   it(
     'should not wait for non-exported promises',


### PR DESCRIPTION
Adds ability to pass variables to the browser in runJS:

```js
import { withBrowser } from 'test-mule';
test(
  'runJS example with argument',
  withBrowser(async ({ utils, screen }) => {
    // element is an ElementHandle (pointer to an element in the browser)
    const element = await screen.getByText(/button/i);
    // we can pass element into runJS and the default exported function can access it as an Element
    await utils.runJS(
      `
        export default (element) => console.log(element);
      `,
      [element],
    );
  }),
);
```

Closes #28 

In #28 I mentioned other syntax options for how to make this possible, open to feedback 👀 