### PR TITLE
Use esbuild instead of babel for tests

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,18 +1,5 @@
 module.exports = (api) => {
-  const isTest = api.env('test');
-
   const isRollup = api.caller((c) => c && c.name === '@rollup/plugin-babel');
-
-  if (isTest)
-    return {
-      plugins: [
-        '@babel/transform-modules-commonjs',
-        // TODO: remove when node 12 is dropped
-        '@babel/plugin-proposal-optional-chaining',
-      ],
-      // not using preset-env here because it slows down the tests a lot
-      presets: ['@babel/preset-typescript'],
-    };
 
   return {
     presets: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
     'test-mule': '<rootDir>/dist/cjs/index.cjs',
   },
   testRunner: 'jest-circus/runner',
+  transform: {
+    '^.+\\.tsx?$': ['esbuild-jest', { sourcemap: true }],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4885,6 +4885,17 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.43.tgz",
       "integrity": "sha512-ZVE2CpootS4jtnfV0bbtJdgRsHEXcMP0P7ZXGfTmNzzhBr2e5ag7Vp3ry0jmw8zduJz4iHzxg4m5jtPxWERz1w=="
     },
+    "esbuild-jest": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/esbuild-jest/-/esbuild-jest-0.5.0.tgz",
+      "integrity": "sha512-AMZZCdEpXfNVOIDvURlqYyHwC8qC1/BFjgsrOiSL1eyiIArVtHL8YAC83Shhn16cYYoAWEW17yZn0W/RJKJKHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.17",
+        "@babel/plugin-transform-modules-commonjs": "^7.12.13",
+        "babel-jest": "^26.6.3"
+      }
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-un-cjs": "^2.3.0",
     "env-paths": "^2.2.0",
     "errorstacks": "^2.3.0",
+    "esbuild-jest": "^0.5.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "jscodeshift": "^0.11.0",


### PR DESCRIPTION
The main rollup build is still using babel (because it needs babel-plugin-un-cjs for a lot of deps)

This PR just switches Jest's transformer to use esbuild instead of Babel. So it should only affect the transpilation of the `*.test.ts` files.