### PR TITLE
Bundle types for @testing-library/dom so people don't have to install @testing-library/dom

### DIFF
--- a/.changeset/many-pears-repeat.md
+++ b/.changeset/many-pears-repeat.md
@@ -1,0 +1,5 @@
+---
+'test-mule': patch
+---
+
+Bundle types for `@testing-library/dom` so people don't have to install `@testing-library/dom` (closes #50)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,8 @@ const mainConfig = {
 const typesConfig = {
   input: 'src/index.ts',
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
-  plugins: [dts()],
+  external: ['puppeteer', 'vite', 'pretty-format'],
+  plugins: [dts({ respectExternal: true })],
 };
 
 export default [


### PR DESCRIPTION
closes #50 

Previously, the types for `@testing-library/dom` were missing for people who installed `test-mule`, so they would have to install `@testing-library/dom` (only for the types since the source code is already bundled).

This PR changes it so the types for `@testing-library/dom` are bundled.