### PR TITLE
Implement `user.selectOptions()`

### DIFF
--- a/.changeset/stale-bats-applaud.md
+++ b/.changeset/stale-bats-applaud.md
@@ -1,0 +1,5 @@
+---
+'test-mule': minor
+---
+
+Implement `user.selectOptions()`

--- a/README.md
+++ b/README.md
@@ -501,6 +501,32 @@ test(
 );
 ```
 
+#### `TestMuleUser.selectOptions(element: ElementHandle, values: ElementHandle | ElementHandle[] | string[] | string, options?: { force?: boolean }): Promise<void>`
+
+Selects the specified option(s) of a `<select>` or a `<select multiple>` element. Values can be passed as either strings (option values) or as [`ElementHandle`](https://pptr.dev/#?product=Puppeteer&version=v7.1.0&show=api-class-elementhandle) references to elements.
+
+**Actionability checks**: It refuses to select in elements that are not [**attached**](#attached) or not [**visible**](#visible). You can override the visibility check by passing `{ force: true }`.
+
+```js
+import { withBrowser } from 'test-mule';
+
+test(
+  'select example',
+  withBrowser(async ({ utils, user, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    await user.selectOptions(selectEl, '2');
+    await expect(selectEl).toHaveValue('2');
+  }),
+);
+```
+
 ### Utilities API: `TestMuleUtils`
 
 The utilities API provides shortcuts for loading and running code in the browser. The methods are wrappers around behavior that can be performed more verbosely with the [Puppeteer `Page` object](#testmulecontextpage). This API is exposed via the [`utils` property in `TestMuleContext`](#testmulecontextutils-testmuleutils)

--- a/src/user-util/index.ts
+++ b/src/user-util/index.ts
@@ -53,7 +53,7 @@ ${el}`;
 // returns { error: ['something bad happened', el]}
 export const error = (
   literals: TemplateStringsArray,
-  ...placeholders: Element[]
+  ...placeholders: (Element | string)[]
 ) => {
   return {
     error: literals.reduce((acc, val, i) => {

--- a/src/user.ts
+++ b/src/user.ts
@@ -215,15 +215,7 @@ Element must be an <input> or <textarea> or an element with the contenteditable 
             } catch (error) {
               return error;
             }
-          }),
-          force,
-        )
-        .then(throwBrowserError(user.clear))
-        .catch(handleForgotAwait);
 
-      await el
-        .evaluateHandle(
-          runWithUtils((utils, el) => {
             if (
               el instanceof HTMLInputElement ||
               el instanceof HTMLTextAreaElement
@@ -233,6 +225,7 @@ Element must be an <input> or <textarea> or an element with the contenteditable 
               return utils.error`user.clear command is only available for <input> and textarea elements, received: ${el}`;
             }
           }),
+          force,
         )
         .then(throwBrowserError(user.clear))
         .catch(handleForgotAwait);

--- a/src/user.ts
+++ b/src/user.ts
@@ -66,14 +66,10 @@ export const testMuleUser = (
       await el
         .evaluateHandle(
           runWithUtils((utils, clickEl, force: boolean) => {
-            try {
-              utils.assertAttached(clickEl);
-              if (!force) utils.assertVisible(clickEl);
-            } catch (error) {
-              return error;
-            }
+            utils.assertAttached(clickEl);
 
             if (!force) {
+              utils.assertVisible(clickEl);
               const clickElRect = clickEl.getBoundingClientRect();
 
               // See if there is an element covering the center of the click target element
@@ -128,12 +124,8 @@ ${coveringEl}`;
       await el
         .evaluateHandle(
           runWithUtils((utils, el, force: boolean) => {
-            try {
-              utils.assertAttached(el);
-              if (!force) utils.assertVisible(el);
-            } catch (error) {
-              return error;
-            }
+            utils.assertAttached(el);
+            if (!force) utils.assertVisible(el);
 
             if (
               el instanceof HTMLInputElement ||
@@ -202,12 +194,8 @@ Element must be an <input> or <textarea> or an element with the contenteditable 
       await el
         .evaluateHandle(
           runWithUtils((utils, el, force: boolean) => {
-            try {
-              utils.assertAttached(el);
-              if (!force) utils.assertVisible(el);
-            } catch (error) {
-              return error;
-            }
+            utils.assertAttached(el);
+            if (!force) utils.assertVisible(el);
 
             if (
               el instanceof HTMLInputElement ||
@@ -249,7 +237,14 @@ const runWithUtils = <Args extends any[], Return extends unknown>(
   return new Function(
     '...args',
     `return import("http://localhost:${port}/@test-mule/user-util")
-    .then((utils) => [utils, (0, ${fn.toString()})(utils, ...args)])
+    .then((utils) => {
+      try {
+        return [utils, (0, ${fn.toString()})(utils, ...args)]
+      } catch (error) {
+        if (error.error) error = error.error
+        return [utils, { error }]
+      }
+    })
     .then(([utils, result]) => {
       if (result && typeof result === 'object' && result.error) {
         const msgWithLiveEls = result.error

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,12 @@ export const jsHandleToArray = async (arrayHandle: JSHandle) => {
 export const assertElementHandle: (
   input: unknown,
   fn: (...params: any[]) => any,
-) => asserts input is ElementHandle = (input, fn) => {
+  messageStart?: string,
+) => asserts input is ElementHandle = (
+  input,
+  fn,
+  messageStart = `element must be an ElementHandle\n\n`,
+) => {
   const type =
     input === null
       ? 'null'
@@ -26,7 +31,6 @@ export const assertElementHandle: (
       ? 'Promise'
       : typeof input;
 
-  const messageStart = `element must be an ElementHandle\n\n`;
   if (type === 'Promise') {
     throw removeFuncFromStackTrace(
       new Error(`${messageStart}Received Promise. Did you forget await?`),

--- a/tests/user/clear.test.ts
+++ b/tests/user/clear.test.ts
@@ -31,7 +31,7 @@ test(
     await utils.injectHTML(`<div contenteditable>text</div>`);
     const div = await screen.getByText(/text/);
     await expect(user.clear(div)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"user.clear command is only available for <input> and textarea elements, received: <div contenteditable=\\"\\">text</div>"`,
+      `"user.clear is only available for <input> and <textarea> elements, received: <div contenteditable=\\"\\">text</div>"`,
     );
   }),
 );
@@ -42,7 +42,7 @@ test(
     await utils.injectHTML(`<div>text</div>`);
     const div = await screen.getByText(/text/);
     await expect(user.clear(div)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"user.clear command is only available for <input> and textarea elements, received: <div>text</div>"`,
+      `"user.clear is only available for <input> and <textarea> elements, received: <div>text</div>"`,
     );
   }),
 );

--- a/tests/user/selectOptions.test.ts
+++ b/tests/user/selectOptions.test.ts
@@ -1,0 +1,157 @@
+import { withBrowser } from 'test-mule';
+
+test(
+  'throws if you pass it a non-element',
+  withBrowser(async ({ user }) => {
+    // @ts-expect-error This is testing the runtime behavior of the wrong type being passed
+    await expect(user.selectOptions(5, ['1', '3'])).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "element must be an ElementHandle
+
+            Received number"
+          `);
+  }),
+);
+
+test(
+  'throws if you pass it the wrong kind of element',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML('<input>');
+    const selectEl = await screen.getByRole('textbox');
+    await expect(
+      user.selectOptions(selectEl, ['1', '3']),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"user.selectOptions is only available for <select> elements, received: <input />"`,
+    );
+  }),
+);
+
+test(
+  'selects option by value for <select>',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    await user.selectOptions(selectEl, '2');
+    await expect(selectEl).toHaveValue('2');
+  }),
+);
+
+test(
+  'throws if you try to select multiple options for a single select',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    await expect(user.selectOptions(selectEl, ['2', '3'])).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+            "Cannot select multiple options on a <select> element without the \`multiple\` attribute:
+
+            <select>[...]</select>"
+          `);
+    await expect(selectEl).toHaveValue('1'); // Default is still selected
+  }),
+);
+
+test(
+  'selects options by value for <select multiple>',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select multiple>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('listbox');
+    await user.selectOptions(selectEl, ['1', '3']);
+    await expect(selectEl).toHaveValue(['1', '3']);
+  }),
+);
+
+test(
+  'selects option by element for <select>',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    const option = await screen.getByRole('option', { name: 'B' });
+    await user.selectOptions(selectEl, option);
+    await expect(selectEl).toHaveValue('2');
+  }),
+);
+
+test(
+  'selects options by element for <select multiple>',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select multiple>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('listbox');
+    const optionB = await screen.getByRole('option', { name: 'B' });
+    const optionC = await screen.getByRole('option', { name: 'C' });
+    await user.selectOptions(selectEl, [optionB, optionC]);
+    await expect(selectEl).toHaveValue(['2', '3']);
+  }),
+);
+
+test(
+  'throws if string value is not an option',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    await expect(
+      user.selectOptions(selectEl, '4'),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not select an option \\"4\\", it is not one of the valid options in the <select>. Valid options are: [\\"1\\",\\"2\\",\\"3\\"]"`,
+    );
+    await expect(selectEl).toHaveValue('1'); // Default is still selected
+  }),
+);
+
+test(
+  'throws if element value is not an option',
+  withBrowser(async ({ user, utils, screen }) => {
+    await utils.injectHTML(`
+      <select>
+        <option value="1">A</option>
+        <option value="2">B</option>
+        <option value="3">C</option>
+      </select>,
+      <option value="3">not-an-option</option>
+    `);
+    const selectEl = await screen.getByRole('combobox');
+    const option = await screen.getByRole('option', { name: 'not-an-option' });
+    await expect(
+      user.selectOptions(selectEl, option),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not select an option <option value=\\"3\\">not-an-option</option>, it is not one of the valid options in the <select>. Valid options are: [\\"1\\",\\"2\\",\\"3\\"]"`,
+    );
+    await expect(selectEl).toHaveValue('1'); // Default is still selected
+  }),
+);

--- a/tests/user/type.test.ts
+++ b/tests/user/type.test.ts
@@ -138,7 +138,7 @@ describe('special character sequences', () => {
       await expect(
         user.type(div, '{selectall}'),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"{selectall} command is only available for <input> and textarea elements, received: <div contenteditable=\\"\\">hello</div>"`,
+        `"{selectall} command is only available for <input> and <textarea> elements, received: <div contenteditable=\\"\\">hello</div>"`,
       );
     }),
   );


### PR DESCRIPTION
Reimplements https://github.com/testing-library/user-event#selectoptionselement-values using Puppeteer methods, and adds it to the `user` object