### PR TITLE
Bump up timeouts in slightly flaky tests

### DIFF
--- a/tests/utils/runJS.test.ts
+++ b/tests/utils/runJS.test.ts
@@ -64,7 +64,7 @@ describe('Waiting for Promises in executed code', () => {
       await utils.runJS(`
         const heading = document.querySelector('h1')
 
-        new Promise(r => setTimeout(r, 10))
+        new Promise(r => setTimeout(r, 50))
           .then(() => heading.remove())
       `);
 
@@ -82,7 +82,7 @@ describe('Waiting for Promises in executed code', () => {
       await utils.runJS(`
         const heading = document.querySelector('h1')
 
-        await new Promise(r => setTimeout(r, 10))
+        await new Promise(r => setTimeout(r, 50))
           .then(() => heading.remove())
       `);
       await expect(heading).not.toBeInTheDocument();


### PR DESCRIPTION
The "should not wait for non-exported promises" test fails like 5% of the time because sometimes the `runJS` call happens to take longer than 10ms. By bumping up the timeout to 50ms, it should be much more reliable.